### PR TITLE
Fix bug in focus DOI

### DIFF
--- a/inst/htmlwidgets/lib/doi/doi_update.js
+++ b/inst/htmlwidgets/lib/doi/doi_update.js
@@ -16,7 +16,7 @@ function doi_update(width, height, values, tree, focus_node_id) {
   var doi_tree = new DoiTree(tree);
   var layout = doi_tree.tree_block(
     focus_node_id,
-      -4, // min doi
+      -3, // min doi
     [width, height],
     [10, 10] // node size
   );

--- a/inst/htmlwidgets/lib/doi/doi_update.js
+++ b/inst/htmlwidgets/lib/doi/doi_update.js
@@ -2,6 +2,7 @@
 function draw_doi(elem, width, height, values, tree, focus_node_id) {
   setup_background(elem, width, height, "#F7F7F7");
   setup_groups(d3.select("svg"));
+  console.log(tree)
   doi_update(
     width,
     height,
@@ -75,6 +76,7 @@ function doi_update(width, height, values, tree, focus_node_id) {
 	return scales.size(d3.mean(cur_values));
       }
     })
+    .text(function(d) { return d.data.depth + "-" + d.data.segment; })
     .on("click",
 	function(d) {
 	  return doi_update(
@@ -85,6 +87,7 @@ function doi_update(width, height, values, tree, focus_node_id) {
 	    d.data.name
 	  );
 	});
+
 
   d3.selectAll(".tree_node")
     .transition(transitioner)

--- a/inst/htmlwidgets/lib/doi/doi_update.js
+++ b/inst/htmlwidgets/lib/doi/doi_update.js
@@ -13,23 +13,25 @@ function draw_doi(elem, width, height, values, tree, focus_node_id) {
 }
 
 function doi_update(width, height, values, tree, focus_node_id) {
+  console.log("Focusing on " + focus_node_id);
   // essential DOI algorithm
   var doi_tree = new DoiTree(tree);
-  var layout = doi_tree.tree_block(
-    focus_node_id,
-    [width, height],
-    [10, 20] // node size
-  );
+  doi_tree.set_doi();
 
-  // setup scales used throughout
   var scales = {
     "size": d3.scaleLinear()
       .domain([0, d3.max(values.value)])
-      .range([2, 15]),
-    "opacity": d3.scalePow().exponent([0.35])
+      .range([3, 35]),
+    "opacity": d3.scalePow().exponent([1e-15])
       .domain(d3.extent(doi_tree.get_attr_array("doi")))
-      .range(["#EDEDED", "#000000"]),
+      .range(["#F7F7F7", "#000000"]),
   };
+
+  var layout = doi_tree.tree_block(
+    focus_node_id,
+    [width, height],
+    [25, 100] // node size
+  );
 
   // bind to data
   var link_selection = d3.select("#links")

--- a/inst/htmlwidgets/lib/doi/doi_update.js
+++ b/inst/htmlwidgets/lib/doi/doi_update.js
@@ -16,19 +16,18 @@ function doi_update(width, height, values, tree, focus_node_id) {
   var doi_tree = new DoiTree(tree);
   var layout = doi_tree.tree_block(
     focus_node_id,
-      -3, // min doi
     [width, height],
-    [10, 10] // node size
+    [10, 20] // node size
   );
 
   // setup scales used throughout
   var scales = {
     "size": d3.scaleLinear()
       .domain([0, d3.max(values.value)])
-      .range([1, 8]),
-    "opacity": d3.scaleLinear()
-      .domain([-4, 0])
-      .range(["#DCDCDC", "#000000"]),
+      .range([2, 15]),
+    "opacity": d3.scalePow().exponent([0.35])
+      .domain(d3.extent(doi_tree.get_attr_array("doi")))
+      .range(["#EDEDED", "#000000"]),
   };
 
   // bind to data

--- a/inst/htmlwidgets/lib/doi/doi_utils.js
+++ b/inst/htmlwidgets/lib/doi/doi_utils.js
@@ -43,7 +43,6 @@ function DoiTreeInternal(tree_json, depth) {
   this.doi = null;
   this.segment = null;
   this.set_tree_fisheye = set_tree_fisheye;
-  this.filter_doi = filter_doi;
   this.set_doi = set_doi;
   this.set_segments = set_segments;
   this.get_block_dois = get_block_dois;
@@ -293,18 +292,6 @@ function get_layout_bounds(focus_node_id, display_dim, node_size) {
 }
 
 /**
- * Filter away nodes unassociated with a DOI
- **/
-function filter_doi(min_doi) {
-  values = {
-    "value": this.get_attr_array("doi"),
-    "unit": this.get_attr_array("name")
-  };
-
-  this.filter_tree(values, min_doi);
-}
-
-/**
  * Filter nodes within a single tree block
  *
  * The tree-blocking algorithm requires filtering away blocks of
@@ -460,6 +447,9 @@ function trim_width(focus_node_id, display_dim, node_size) {
   console.log("dois")
   console.log(average_block_dois(block_dois))
   console.log(block_dois)
+  console.log(this)
+  console.log(focus_node_block)
+
   var average_dois = flatten_nested_object(
     average_block_dois(block_dois)
   );
@@ -483,6 +473,7 @@ function trim_width(focus_node_id, display_dim, node_size) {
 	  console.log("filtering")
 	  console.log(depth)
 	  console.log(segment)
+	  console.log(sorted_dois[i])
 	  this.filter_block(depth, segment);
 	} else {
 	  console.log("avoiding")
@@ -510,9 +501,8 @@ function trim_width(focus_node_id, display_dim, node_size) {
  *
  * @return The filtered tree and nodes.
  **/
-function tree_block(focus_node_id, min_doi, display_dim, node_size) {
+function tree_block(focus_node_id, display_dim, node_size) {
   this.set_doi(focus_node_id);
-  this.filter_doi(min_doi);
   this.set_segments();
   this.trim_width(focus_node_id, display_dim, node_size);
   return this.get_layout(focus_node_id, display_dim, node_size);

--- a/vignettes/setup_doi.Rmd
+++ b/vignettes/setup_doi.Rmd
@@ -30,7 +30,7 @@ library("zoo")
 data(GlobalPatterns)
 
 GPr <- transform_sample_counts(GlobalPatterns, function(x) x / sum(x) )
-GPfr <- filter_taxa(GPr, function(x) mean(x) > 1e-4, TRUE)
+GPfr <- filter_taxa(GPr, function(x) mean(x) > 1e-3, TRUE)
 taxa <- taxa_edgelist(tax_table(GPfr))
 
 values <- tree_sum(
@@ -44,5 +44,6 @@ values <- data.frame(
   stringsAsFactors = FALSE
 )
 
-doi_tree(values, taxa, "Bacteria", "Bacteria", width = 10000, height = 500)
+install()
+doi_tree(values, taxa, "Bacteria", "Bacteria", width = 1000, height = 500)
 ```

--- a/vignettes/setup_doi.Rmd
+++ b/vignettes/setup_doi.Rmd
@@ -45,5 +45,5 @@ values <- data.frame(
 )
 
 install()
-doi_tree(values, taxa, "Bacteria", "Bacteria", width = 5000, height = 500)
+doi_tree(values, taxa, "Bacteria", "Bacteria", width = 1000, height = 500)
 ```

--- a/vignettes/setup_doi.Rmd
+++ b/vignettes/setup_doi.Rmd
@@ -45,5 +45,5 @@ values <- data.frame(
 )
 
 install()
-doi_tree(values, taxa, "Bacteria", "Bacteria", width = 1000, height = 500)
+doi_tree(values, taxa, "Bacteria", "Bacteria", width = 2000, height = 4000)
 ```

--- a/vignettes/setup_doi.Rmd
+++ b/vignettes/setup_doi.Rmd
@@ -45,5 +45,5 @@ values <- data.frame(
 )
 
 install()
-doi_tree(values, taxa, "Bacteria", "Bacteria", width = 1000, height = 500)
+doi_tree(values, taxa, "Bacteria", "Bacteria", width = 5000, height = 500)
 ```


### PR DESCRIPTION
This closes #17. It was actually caused by a bug in the tree segmentation, not in the block filtering. The issue is that segmentation can't naively be computed recursively, since the 0th child of one subtree should not be put in the same segment as the 0th child in another subtree. We've also removed the min_doi filter, which closes #10 (though not exactly in the way that pull request explained, this seems cleaner either way).
