### PR TITLE
Refactor for more fluid interaction

### DIFF
--- a/inst/htmlwidgets/lib/doi/sankey_update.js
+++ b/inst/htmlwidgets/lib/doi/sankey_update.js
@@ -205,6 +205,6 @@ function sankey_update(elem,
   d3.select(elem)
     .selectAll("[class^='tree_link']")
     .on("click", function(d) {
-      return sankey_update_wrapper(d.target.data.name);
+      return sankey_update_wrapper(d.source.data.name);
     });
 }

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -159,6 +159,24 @@ function get_line_data(values, cur_unit) {
   });
 }
 
+/**
+ * Precompute various forms of "values" to increase performance
+ *
+ * We don't want to recompute these forms of values every time a brush is moved.
+ *
+ * @param {object} values An object with three subarrays,
+ *       - time {array of float} The times associated with Tree nodes.
+ *       - value {array of float} The y values associated with Tree nodes.
+ *       - unit {array of string} The node names associated with values.
+ *     The i^th element in each of the three arrays correspond to the same
+ *     entity.
+ * @return {object} reshaped An object with the following elements,
+ *       - {object} values This is the same as the input values object.
+ *       - {pairs} An object of arrays with time / value pairs for each time
+ *                 series line. For example, [{"time": 0, "value": 1}, ...]
+ *       - {dvalues} A object of arrays keyed by series IDs and giving y-values
+ *                   for each series.
+ **/
 function get_reshaped_values(values) {
   var reshaped = {
     "values": values,

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -149,13 +149,22 @@ function draw_treebox(elem, width, height, values, tree, size_min, size_max) {
 function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
   var scales = get_scales(values, width, height, size_min, size_max);
   var line_data = setup_tree_ts(elem, width, height, values);
+
+
+  var units = d3.set(values.unit).values();
+  var svg_data = {};
+  for (var i = 0; i < units.length; i++) {
+    svg_data[units[i]] = get_line_data(values, units[i]);
+  }
+
   var update_fun = update_factory(
     timebox_update,
     elem,
     values,
     tree,
     [],
-    scales
+    scales,
+    svg_data
   );
 
   var zoom_brush = d3.brush()
@@ -207,7 +216,7 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
   add_button(elem, "new box", add_fun);
   add_button(elem, "change focus", function() { return change_focus(elem); });
   add_button(elem, "remove box", remove_fun);
-  timebox_update(elem, values, tree, [], scales);
+  timebox_update(elem, values, tree, [], scales, svg_data);
 }
 
 /**
@@ -229,9 +238,9 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
  * @side-effects Updates the timebox display to highlight the currently selected
  *     series.
  **/
-function timebox_update(elem, values, tree, cur_lines, scales) {
-  draw_zoom(elem, values, cur_lines, scales);
-  draw_ts(elem, values, cur_lines, scales, false);
+function timebox_update(elem, values, tree, cur_lines, scales, line_data) {
+  draw_zoom(elem, values, cur_lines, scales, line_data);
+  draw_ts(elem, values, cur_lines, scales, false, line_data);
   draw_tree(elem, values, cur_lines, tree, scales, true);
 }
 
@@ -257,9 +266,9 @@ function timebox_update(elem, values, tree, cur_lines, scales) {
  * @return {function} A version of the base_function function with options
  *    filled in according to the arguments in the factory.
  **/
-function update_factory(base_fun, elem, values, tree, cur_lines, cur_scales) {
+function update_factory(base_fun, elem, values, tree, cur_lines, cur_scales, line_data) {
   function f(cur_lines, cur_scales) {
-    base_fun(elem, values, tree, cur_lines, cur_scales);
+    base_fun(elem, values, tree, cur_lines, cur_scales, line_data);
   }
 
   return f;

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -177,6 +177,11 @@ function get_reshaped_values(values) {
   return reshaped;
 }
 
+/**
+ *
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
+ **/
 function zoom_brush_fun(elem, pairs, scales, combine_fun, update_fun) {
   var cur_extent = d3.brushSelection(
     d3.select("#zoom_ts").select(".zoom_brush").node()
@@ -371,6 +376,8 @@ function treebox_update(elem, reshaped, tree, cur_lines, scales) {
  *
  * @param  {d3 selection} elem The html selection on which the DOI tree display
  *     will be drawn.
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param {function} combine_fun The function used for combining units across
  *     brush selections. This is usually the intersection or union of selections
  *    coming from any individual brush.
@@ -401,11 +408,8 @@ function selected_ts(elem, pairs, combine_fun, scales) {
  *
  * @param  {d3 selection} elem The html selection on which the DOI tree display
  *     will be drawn.
- * @param {object} unit_values An object that contains data for each line
- *     element. This has the form
- *       {"a": [{"time": 0, "value": 1}, ...],
- *        "b": [{"time": 0, "value": 3}, ...]}
- *     for two time series with ids "a" and "b".
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param {Object of d3.scales} scales An object with different scales for
  *     positions and sizes for the time series and nodes.
  * @param {function} update_fun The function to execute every time the brush is
@@ -427,11 +431,8 @@ function brush_fun(elem, pairs, scales, update_fun, combine_fun) {
  *
  * @param  {d3 selection} elem The html selection on which the DOI tree display
  *     will be drawn.
- * @param {object} unit_values An object that contains data for each line
- *     element. This has the form
- *       {"a": [{"time": 0, "value": 1}, ...],
- *        "b": [{"time": 0, "value": 3}, ...]}
- *     for two time series with ids "a" and "b".
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param {Object of d3.scales} scales An object with different scales for
  *     positions and sizes for the time series and nodes.
  * @param {function} update_fun The function to execute every time the brush is
@@ -480,11 +481,8 @@ function new_brush(elem, pairs, scales, update_fun, extent, combine_fun) {
  *
  * @param  {d3 selection} elem The html selection on which the DOI tree display
  *     will be drawn.
- * @param {object} unit_values An object that contains data for each line
- *     element. This has the form
- *       {"a": [{"time": 0, "value": 1}, ...],
- *        "b": [{"time": 0, "value": 3}, ...]}
- *     for two time series with ids "a" and "b".
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param {Object of d3.scales} scales An object with different scales for
  *     positions and sizes for the time series and nodes.
  * @param {function} update_fun The function to execute every time the brush is

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -244,8 +244,8 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
  *     series.
  **/
 function timebox_update(elem, values, tree, cur_lines, scales, line_data, unit_values) {
-  draw_zoom(elem, values, cur_lines, scales, line_data);
-  draw_ts(elem, values, cur_lines, scales, false, line_data);
+  draw_zoom(elem, cur_lines, scales, line_data);
+  draw_ts(elem, cur_lines, scales, false, line_data);
   draw_tree(elem, values, cur_lines, tree, scales, true, unit_values);
 }
 
@@ -301,7 +301,7 @@ function update_factory(base_fun, elem, values, tree, cur_lines, cur_scales, lin
  *     order to highlight the currently selected IDs.
  **/
 function treebox_update(elem, values, tree, cur_lines, scales) {
-  draw_ts(elem, values, cur_lines, scales, true);
+  draw_ts(elem, cur_lines, scales, true);
   draw_tree(elem, values, cur_lines, tree, scales, false);
 }
 

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -87,8 +87,8 @@ function draw_treebox(elem, width, height, values, tree, size_min, size_max) {
       zoom_brush_fun(
 	elem,
 	reshaped.pairs,
-	scales,
 	brush_nodes_union,
+	scales,
 	update_fun
       );
     })
@@ -178,35 +178,6 @@ function get_reshaped_values(values) {
 }
 
 /**
- *
- * @param {array of objects} pairs An with time / value pairs for each time
- *      series line. For example, [{"time": 0, "value": 1}, ...]
- **/
-function zoom_brush_fun(elem, pairs, scales, combine_fun, update_fun) {
-  var cur_extent = d3.brushSelection(
-    d3.select("#zoom_ts").select(".zoom_brush").node()
-  );
-
-  // reset domains for scales
-  scales.x.domain(
-    [scales.zoom_x.invert(cur_extent[0][0]),
-     scales.zoom_x.invert(cur_extent[1][0])]
-  );
-  scales.y.domain(
-    [scales.zoom_y.invert(cur_extent[1][1]),
-     scales.zoom_y.invert(cur_extent[0][1])]
-  );
-
-  var units = selected_ts(
-    elem,
-    pairs,
-    combine_fun,
-    scales
-  );
-  update_fun(units, scales);
-}
-
-/**
  * Setup and draw the initial timeboxes display
  *
  * @param  {d3 selection} elem The html selection on which the DOI tree display
@@ -247,8 +218,8 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
       zoom_brush_fun(
 	elem,
 	reshaped.pairs,
-	scales,
 	brush_ts_intersection,
+	scales,
 	update_fun
       );
     })
@@ -326,7 +297,7 @@ function timebox_update(elem, reshaped, tree, cur_lines, scales) {
  *       - unit {array of string} The node names associated with values.
  *     The i^th element in each of the three arrays correspond to the same
  *     entity.
- * @param tree {Tree} A tree object (actually, a properly nested JSON would
+ * @param {Tree} tree A tree object (actually, a properly nested JSON would
  *     suffice) on which we can call d3.hierarchy to compute the layout.
  * @param {array of strings} cur_lines An array containing ids of the nodes and
  *     series to highlight.
@@ -369,7 +340,6 @@ function treebox_update(elem, reshaped, tree, cur_lines, scales) {
   draw_ts(elem, reshaped.pairs, cur_lines, scales, true);
   draw_tree(elem, reshaped.dvalues, cur_lines, tree, scales, false);
 }
-
 
 /**
  * Identify which time series are selected (by either Time or Treeboxes)
@@ -423,6 +393,48 @@ function selected_ts(elem, pairs, combine_fun, scales) {
  **/
 function brush_fun(elem, pairs, scales, update_fun, combine_fun) {
   var units = selected_ts(elem, pairs, combine_fun, scales);
+  update_fun(units, scales);
+}
+
+/**
+ * Function to call every time brush in zoom box is moved
+ *
+ * @param  {d3 selection} elem The html selection on which the DOI tree display
+ *     will be drawn.
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
+ * @param {function} combine_fun The function used for combining units across
+ *     brush selections. This is usually the intersection or union of selections
+ *    coming from any individual brush.
+ * @param {Object of d3.scales} scales An object with different scales for
+ *     positions and sizes for the time series and nodes.
+ * @param {function} update_fun The function to execute every time the brush is
+ *     updated.
+ * @return null
+ * @side-effects Redraws the main time series according to the scales set by the
+ *     zoom brush on the top right.
+ **/
+function zoom_brush_fun(elem, pairs, combine_fun, scales, update_fun) {
+  var cur_extent = d3.brushSelection(
+    d3.select("#zoom_ts").select(".zoom_brush").node()
+  );
+
+  // reset domains for scales
+  scales.x.domain(
+    [scales.zoom_x.invert(cur_extent[0][0]),
+     scales.zoom_x.invert(cur_extent[1][0])]
+  );
+  scales.y.domain(
+    [scales.zoom_y.invert(cur_extent[1][1]),
+     scales.zoom_y.invert(cur_extent[0][1])]
+  );
+
+  var units = selected_ts(
+    elem,
+    pairs,
+    combine_fun,
+    scales
+  );
   update_fun(units, scales);
 }
 

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -272,7 +272,7 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
 function timebox_update(elem, reshaped, tree, cur_lines, scales) {
   draw_zoom(elem, reshaped.pairs, cur_lines, scales);
   draw_ts(elem, reshaped.pairs, cur_lines, scales, false);
-  draw_tree(elem, reshaped.values, cur_lines, tree, scales, true, reshaped.dvalues);
+  draw_tree(elem, reshaped.dvalues, cur_lines, tree, scales, true);
 }
 
 /**

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -153,8 +153,12 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
 
   var units = d3.set(values.unit).values();
   var svg_data = {};
+  var unit_values = {};
   for (var i = 0; i < units.length; i++) {
     svg_data[units[i]] = get_line_data(values, units[i]);
+    unit_values[units[i]] = svg_data[units[i]].map(
+      function(d) { return d.value; }
+    );
   }
 
   var update_fun = update_factory(
@@ -164,7 +168,8 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
     tree,
     [],
     scales,
-    svg_data
+    svg_data,
+    unit_values
   );
 
   var zoom_brush = d3.brush()
@@ -216,7 +221,7 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
   add_button(elem, "new box", add_fun);
   add_button(elem, "change focus", function() { return change_focus(elem); });
   add_button(elem, "remove box", remove_fun);
-  timebox_update(elem, values, tree, [], scales, svg_data);
+  timebox_update(elem, values, tree, [], scales, svg_data, unit_values);
 }
 
 /**
@@ -238,10 +243,10 @@ function draw_timebox(elem, width, height, values, tree, size_min, size_max) {
  * @side-effects Updates the timebox display to highlight the currently selected
  *     series.
  **/
-function timebox_update(elem, values, tree, cur_lines, scales, line_data) {
+function timebox_update(elem, values, tree, cur_lines, scales, line_data, unit_values) {
   draw_zoom(elem, values, cur_lines, scales, line_data);
   draw_ts(elem, values, cur_lines, scales, false, line_data);
-  draw_tree(elem, values, cur_lines, tree, scales, true);
+  draw_tree(elem, values, cur_lines, tree, scales, true, unit_values);
 }
 
 /**
@@ -266,9 +271,9 @@ function timebox_update(elem, values, tree, cur_lines, scales, line_data) {
  * @return {function} A version of the base_function function with options
  *    filled in according to the arguments in the factory.
  **/
-function update_factory(base_fun, elem, values, tree, cur_lines, cur_scales, line_data) {
+function update_factory(base_fun, elem, values, tree, cur_lines, cur_scales, line_data, unit_values) {
   function f(cur_lines, cur_scales) {
-    base_fun(elem, values, tree, cur_lines, cur_scales, line_data);
+    base_fun(elem, values, tree, cur_lines, cur_scales, line_data, unit_values);
   }
 
   return f;

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -80,7 +80,27 @@ function draw_treebox(elem, width, height, values, tree, size_min, size_max) {
     scales
   );
 
-  var brush_extent = [[0, 0], [0.8 * width, 0.39 * height]]; // only brush over tree
+
+  // add brush in top right for zooming
+  var zoom_brush = d3.brush()
+    .on("brush", function() {
+      zoom_brush_fun(
+	elem,
+	reshaped.pairs,
+	scales,
+	brush_nodes_union,
+	update_fun
+      );
+    })
+    .extent([[0.8 * width, 0.05 * height], [width, 0.15 * height]]);
+
+  d3.select("#zoom_ts")
+    .append("g")
+    .classed("zoom_brush", "true")
+    .call(zoom_brush);
+
+  // draw main brush for selecting tree nodes
+  var brush_extent = [[0, 0], [0.8 * width, 0.39 * height]];
   function add_fun() {
     new_brush(
       elem,

--- a/inst/htmlwidgets/lib/doi/ts_update.js
+++ b/inst/htmlwidgets/lib/doi/ts_update.js
@@ -68,7 +68,7 @@ function setup_tree_ts(elem, width, height) {
  **/
 function draw_treebox(elem, width, height, values, tree, size_min, size_max) {
   var scales = get_scales(values, 0.9 * width, height, size_min, size_max);
-  var line_data = setup_tree_ts(elem, width, height);
+  setup_tree_ts(elem, width, height);
   var reshaped = get_reshaped_values(values);
 
   var update_fun = update_factory(
@@ -85,7 +85,7 @@ function draw_treebox(elem, width, height, values, tree, size_min, size_max) {
   function add_fun() {
     new_brush(
       elem,
-      line_data,
+      reshaped.pairs,
       scales,
       update_fun,
       brush_extent,
@@ -96,7 +96,7 @@ function draw_treebox(elem, width, height, values, tree, size_min, size_max) {
   function remove_fun() {
     remove_brush(
       elem,
-      line_data,
+      reshaped.dvalues,
       scales,
       update_fun,
       brush_nodes_union
@@ -106,7 +106,7 @@ function draw_treebox(elem, width, height, values, tree, size_min, size_max) {
   add_button(elem, "new box", add_fun);
   add_button(elem, "change focus", function() { return change_focus(elem); });
   add_button(elem, "remove box", remove_fun);
-  treebox_update(elem, values, tree, [], scales);
+  treebox_update(elem, reshaped, tree, [], scales);
 }
 
 /**
@@ -326,9 +326,9 @@ function update_factory(base_fun, elem, reshaped, tree, cur_lines, cur_scales) {
  * @side_effects Redraws the tree and time series in the treebox display in
  *     order to highlight the currently selected IDs.
  **/
-function treebox_update(elem, values, tree, cur_lines, scales, line_data) {
-  draw_ts(elem, cur_lines, scales, true, line_data);
-  draw_tree(elem, values, cur_lines, tree, scales, false);
+function treebox_update(elem, reshaped, tree, cur_lines, scales) {
+  draw_ts(elem, reshaped.pairs, cur_lines, scales, true);
+  draw_tree(elem, reshaped.dvalues, cur_lines, tree, scales, false);
 }
 
 
@@ -350,6 +350,7 @@ function selected_ts(elem, pairs, combine_fun, scales) {
       .selectAll(".brush")
       .nodes();
   var units = [];
+
   if (brushes.length !== 0) {
     units = combine_fun(
       elem,
@@ -414,12 +415,12 @@ function brush_fun(elem, pairs, scales, update_fun, combine_fun) {
  * @return null
  * @side-effects Adds a new brush to elem and focuses the display on it.
  **/
-function new_brush(elem, dvalues, scales, update_fun, extent, combine_fun) {
+function new_brush(elem, pairs, scales, update_fun, extent, combine_fun) {
   var brush = d3.brush()
       .on("brush", function() {
 	brush_fun(
 	  elem,
-	  dvalues,
+	  pairs,
 	  scales,
 	  update_fun,
 	  combine_fun

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -78,13 +78,13 @@ function draw_ts(elem, dvalues, cur_lines, scales, mouseover_text) {
       .on("mouseover",
 	  function(d) {
 	    var cur_data = dvalues[d];
-	    var cur_y = cur_data[cur_data.length - 1].value;
-	    var cur_x = cur_data[cur_data.length - 1].time;
+	    var cur_y = cur_data[0].value;
+	    var cur_x = cur_data[0].time;
 
 	    d3.select(elem)
 	      .select("#mouseover")
 	      .attrs({
-		"transform": "translate(" + (5 + scales.x(cur_x)) + "," +
+		"transform": "translate(" + 4+ "," +
 		  scales.y(cur_y) + ")"
 	      });
 

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -70,14 +70,14 @@ function get_scales(values, width, height, size_min, size_max) {
  * @return null
  * @side-effects Draws the static time series (svg-paths) on the elem.
  **/
-function draw_ts(elem, values, cur_lines, scales, mouseover_text) {
-  var ts_select = draw_ts_internal(elem, values, scales, "all_ts", cur_lines);
+function draw_ts(elem, values, cur_lines, scales, mouseover_text, line_data) {
+  var ts_select = draw_ts_internal(elem, values, scales, "all_ts", cur_lines, line_data);
 
   if (mouseover_text) {
     ts_select
       .on("mouseover",
 	  function(d) {
-	    var cur_data = get_line_data(values, d);
+	    var cur_data = line_data[d];
 	    var cur_y = cur_data[cur_data.length - 1].value;
 	    var cur_x = cur_data[cur_data.length - 1].time;
 
@@ -253,7 +253,7 @@ function draw_tree(elem, values, cur_lines, tree, scales, mouseover_text) {
   }
 }
 
-function draw_ts_internal(elem, values, scales, cur_id, cur_lines) {
+function draw_ts_internal(elem, values, scales, cur_id, cur_lines, line_data) {
   var line_fun = d3.line()
       .x(function(d) { return scales.x(d.time); })
       .y(function(d) { return scales.y(d.value); });
@@ -276,7 +276,7 @@ function draw_ts_internal(elem, values, scales, cur_id, cur_lines) {
       "opacity": 0.1,
       "d": function(d) {
 	return line_fun(
-	  get_line_data(values, d)
+	  line_data[d]
 	);
       }
     });
@@ -298,7 +298,7 @@ function draw_ts_internal(elem, values, scales, cur_id, cur_lines) {
       },
       "d": function(d) {
 	return line_fun(
-	  get_line_data(values, d)
+	  line_data[d]
 	);
       },
       "opacity": function(d) {
@@ -312,9 +312,9 @@ function draw_ts_internal(elem, values, scales, cur_id, cur_lines) {
   return ts_selection;
 }
 
-function draw_zoom(elem, values, cur_lines, scales) {
+function draw_zoom(elem, values, cur_lines, scales, line_data) {
   var cur_scales = {"x": scales.zoom_x, "y": scales.zoom_y};
-  draw_ts_internal(elem, values, cur_scales, "zoom_ts", cur_lines);
+  draw_ts_internal(elem, values, cur_scales, "zoom_ts", cur_lines, line_data);
 }
 
 /*******************************************************************************

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -556,8 +556,8 @@ function lines_in_box(pairs, box_extent) {
  * @return units {array of strings} The ids for tree nodes contained in any of
  *     the specified brushes.
  **/
-function brush_nodes_union(elem, brushes) {
-  var scales = {
+function brush_nodes_union(elem, pairs, brushes, scales) {
+  scales = {
     "x": d3.scaleLinear(),
     "y": d3.scaleLinear()
   };

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -70,8 +70,8 @@ function get_scales(values, width, height, size_min, size_max) {
  * @return null
  * @side-effects Draws the static time series (svg-paths) on the elem.
  **/
-function draw_ts(elem, values, cur_lines, scales, mouseover_text, line_data) {
-  var ts_select = draw_ts_internal(elem, values, scales, "all_ts", cur_lines, line_data);
+function draw_ts(elem, cur_lines, scales, mouseover_text, line_data) {
+  var ts_select = draw_ts_internal(elem, scales, "all_ts", cur_lines, line_data);
 
   if (mouseover_text) {
     ts_select
@@ -122,7 +122,7 @@ function timebox_link_attrs(cur_lines, scales, unit_values) {
   var attr_funs = link_attr_defaults();
   attr_funs.stroke = "#F0F0F0";
 
-  attr_funs.stroke_width = function(d) {
+  attr_funs["stroke-width"] = function(d) {
     var cur_values = unit_values[d.target.data.name[0]];
     return scales.r(d3.mean(cur_values));
   };
@@ -245,12 +245,12 @@ function draw_tree(elem, values, cur_lines, tree, scales, mouseover_text, unit_v
   }
 }
 
-function draw_ts_internal(elem, values, scales, cur_id, cur_lines, line_data) {
+function draw_ts_internal(elem, scales, cur_id, cur_lines, line_data) {
   var line_fun = d3.line()
       .x(function(d) { return scales.x(d.time); })
       .y(function(d) { return scales.y(d.value); });
 
-  var units = d3.set(values.unit).values();
+  var units = Object.keys(line_data);
   var ts_selection = d3.select(elem)
       .select("#" + cur_id)
       .selectAll("." + cur_id)
@@ -304,9 +304,9 @@ function draw_ts_internal(elem, values, scales, cur_id, cur_lines, line_data) {
   return ts_selection;
 }
 
-function draw_zoom(elem, values, cur_lines, scales, line_data) {
+function draw_zoom(elem, cur_lines, scales, line_data) {
   var cur_scales = {"x": scales.zoom_x, "y": scales.zoom_y};
-  draw_ts_internal(elem, values, cur_scales, "zoom_ts", cur_lines, line_data);
+  draw_ts_internal(elem, cur_scales, "zoom_ts", cur_lines, line_data);
 }
 
 /*******************************************************************************

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -232,8 +232,20 @@ function draw_tree(elem, dvalues, cur_lines, tree, scales, mouseover_text) {
 }
 
 /**
+ * Generic time series drawing function
+ *
+ * @param  {d3 selection} elem The html selection on which the DOI tree display
+ *     will be drawn.
  * @param {array of objects} pairs An with time / value pairs for each time
  *      series line. For example, [{"time": 0, "value": 1}, ...]
+ * @param {Object of d3.scales} scales An object with different scales for
+ *     positions and sizes for the time series and nodes.
+ * @param {string} cur_id The ID of the html element on which to draw the time
+ *     series.
+ * @param {array of strings} cur_lines An array containing ids of the nodes and
+ *     series to highlight.
+ * @return {d3 selection} ts_selection The d3 html selection with bound data.
+ * @side-effects Draws the ts encoded in pairs onto the element elem.
  **/
 function draw_ts_internal(elem, pairs, scales, cur_id, cur_lines) {
   var line_fun = d3.line()
@@ -294,9 +306,23 @@ function draw_ts_internal(elem, pairs, scales, cur_id, cur_lines) {
   return ts_selection;
 }
 
-function draw_zoom(elem, paris, cur_lines, scales) {
+/**
+ * Draw time series used for zooming into series
+ *
+ * @param  {d3 selection} elem The html selection on which the tree / timebox
+ *     display will be drawn.
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
+ * @param {array of strings} cur_lines An array containing ids of the nodes and
+ *     series to highlight.
+ * @param {Object of d3.scales} scales An object with different scales for
+ *     positions and sizes for the time series and nodes.
+ * @return null
+ * @side-effects Draws zooming time series on the #zoom_ts group on elem
+ **/
+function draw_zoom(elem, pairs, cur_lines, scales) {
   var cur_scales = {"x": scales.zoom_x, "y": scales.zoom_y};
-  draw_ts_internal(elem, paris, cur_scales, "zoom_ts", cur_lines);
+  draw_ts_internal(elem, pairs, cur_scales, "zoom_ts", cur_lines);
 }
 
 /*******************************************************************************
@@ -442,7 +468,7 @@ function get_box_extent(brush, scales) {
  *     check are located.
  * @param {array of objects} pairs An with time / value pairs for each time
  *      series line. For example, [{"time": 0, "value": 1}, ...]
- * @param brushes {array of d3-brush} An array containing all the d3-brushes on
+ * @param {array of d3-brush} brushes An array containing all the d3-brushes on
  *     the display.
  * @return units {array of strings} The ids for tree nodes contained in any of
  *     the specified brushes.

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -118,16 +118,12 @@ function draw_ts(elem, values, cur_lines, scales, mouseover_text, line_data) {
  *     be directly input to a d3 path selection's .attr() to give styling /
  *     positioning for text on time + treeboxes tree nodes.
  **/
-function timebox_link_attrs(values, cur_lines, scales) {
+function timebox_link_attrs(cur_lines, scales, unit_values) {
   var attr_funs = link_attr_defaults();
   attr_funs.stroke = "#F0F0F0";
 
   attr_funs.stroke_width = function(d) {
-    var cur_values = get_matching_subarray(
-      values.value,
-      values.unit,
-      d.target.data.name[0]
-    );
+    var cur_values = unit_values[d.target.data.name[0]];
     return scales.r(d3.mean(cur_values));
   };
 
@@ -152,15 +148,11 @@ function timebox_link_attrs(values, cur_lines, scales) {
  *     be directly input to a d3 circles selection's .attr() to give styling /
  *     positioning for text on time + treeboxes tree nodes.
  **/
-function timebox_node_attrs(values, cur_lines, scales) {
+function timebox_node_attrs(cur_lines, scales, unit_values) {
   var attr_funs = node_attr_defaults();
 
   attr_funs.r = function(d) {
-    var cur_values = get_matching_subarray(
-      values.value,
-      values.unit,
-      d.data.name[0]
-    );
+    var cur_values = unit_values[d.data.name[0]];
     return 1.2 * scales.r(d3.mean(cur_values));
   };
 
@@ -200,7 +192,7 @@ function timebox_node_attrs(values, cur_lines, scales) {
  * @side-effects Draws the static tree structure (circles and paths between
  *     them) on elem.
  **/
-function draw_tree(elem, values, cur_lines, tree, scales, mouseover_text) {
+function draw_tree(elem, values, cur_lines, tree, scales, mouseover_text, unit_values) {
   var hierarchy = d3.hierarchy(tree);
 
   // width + height info are in the scales
@@ -214,7 +206,7 @@ function draw_tree(elem, values, cur_lines, tree, scales, mouseover_text) {
     d3.select(elem).select("#links"),
     layout.links(),
     "tree_link",
-    timebox_link_attrs(values, cur_lines, scales),
+    timebox_link_attrs(cur_lines, scales, unit_values),
     100
   );
 
@@ -224,7 +216,7 @@ function draw_tree(elem, values, cur_lines, tree, scales, mouseover_text) {
     d3.select(elem).select("#nodes"),
     layout.descendants(),
     "tree_node",
-    timebox_node_attrs(values, cur_lines, scales),
+    timebox_node_attrs(cur_lines, scales, unit_values),
     100
   );
 

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -50,14 +50,10 @@ function get_scales(values, width, height, size_min, size_max) {
 /**
  * Draw static TS associated with time / treeboxes
  *
- * @param elem {d3 selection} The html selection on which all the brushes to
+ * @param {d3 selection} elem The html selection on which all the brushes to
  *     check are located.
- * @param {object} values An object with three subarrays,
- *       - time {array of float} The times associated with Tree nodes.
- *       - value {array of float} The y values associated with Tree nodes.
- *       - unit {array of string} The node names associated with values.
- *     The i^th element in each of the three arrays correspond to the same
- *     entity.
+ * @param {object of arrays} dvalues An object whose keys are series IDs and
+ *     whose values are the series y values associated with each ID.
  * @param cur_lines {array of string} An array of IDs for the time series /
  *     nodes that are currently being selected by either timeboxes or treeboxes.
  *     This will be used to highlight those nodes in the tree (and mute the
@@ -102,11 +98,8 @@ function draw_ts(elem, dvalues, cur_lines, scales, mouseover_text) {
 /**
  * Specify attribute functions for tree links in time + treeboxes
  *
- * @param {object} values An object with three subarrays,
- *       - value {array of float} The y values associated with Tree nodes.
- *       - unit {array of string} The node names associated with values.
- *     The i^th element in each of the three arrays correspond to the same
- *     entity.
+ * @param {object of arrays} dvalues An object whose keys are series IDs and
+ *     whose values are the series y values associated with each ID.
  * @param {array of string} cur_lines An array of IDs for the time series /
  *     nodes that are currently being selected by either timeboxes or treeboxes.
  *     This will be used to highlight those nodes in the tree (and mute the
@@ -133,11 +126,8 @@ function timebox_link_attrs(dvalues, cur_lines, scales) {
 /**
  * Specify attribute functions for tree nodes in time + treeboxes
  *
- * @param {object} values An object with three subarrays,
- *       - value {array of float} The y values associated with Tree nodes.
- *       - unit {array of string} The node names associated with values.
- *     The i^th element in each of the three arrays correspond to the same
- *     entity.
+ * @param {object of arrays} dvalues An object whose keys are series IDs and
+ *     whose values are the series y values associated with each ID.
  * @param cur_lines {array of string} An array of IDs for the time series /
  *     nodes that are currently being selected by either timeboxes or treeboxes.
  *     This will be used to highlight those nodes in the tree (and mute the
@@ -171,12 +161,8 @@ function timebox_node_attrs(dvalues, cur_lines, scales) {
  *
  * @param elem {d3 selection} The html selection on which all the brushes to
  *     check are located.
- * @param {object} values An object with three subarrays,
- *       - time {array of float} The times associated with Tree nodes.
- *       - value {array of float} The y values associated with Tree nodes.
- *       - unit {array of string} The node names associated with values.
- *     The i^th element in each of the three arrays correspond to the same
- *     entity.
+ * @param {object of arrays} dvalues An object whose keys are series IDs and
+ *     whose values are the series y values associated with each ID.
  * @param cur_lines {array of string} An array of IDs for the time series /
  *     nodes that are currently being selected by either timeboxes or treeboxes.
  *     This will be used to highlight those nodes in the tree (and mute the
@@ -245,6 +231,10 @@ function draw_tree(elem, dvalues, cur_lines, tree, scales, mouseover_text) {
   }
 }
 
+/**
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
+ **/
 function draw_ts_internal(elem, pairs, scales, cur_id, cur_lines) {
   var line_fun = d3.line()
       .x(function(d) { return scales.x(d.time); })
@@ -450,6 +440,8 @@ function get_box_extent(brush, scales) {
  *
  * @param elem {d3 selection} The html selection on which all the time series to
  *     check are located.
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param brushes {array of d3-brush} An array containing all the d3-brushes on
  *     the display.
  * @return units {array of strings} The ids for tree nodes contained in any of
@@ -496,8 +488,8 @@ function point_in_box(point, box_extent) {
 /**
  * Check whether a line contains any points within the box_extent
  *
- * @param unit_values {array of ["time": float, "value": float]} An array specifying the time
- *     series structure. Each array element is a length two [time, value] array.
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param box_extent {Object} An object specifying the bounds for nodes which we
  *     should return as "in the box". It must have the keys,
  *       - x_min {float} The minimum x-value for the node to in order for it to
@@ -521,11 +513,8 @@ function line_in_box(pairs, box_extent) {
 /**
  * Return ids associated with any time series contained in a given brush
  *
- * @param unit_values {object} An object whose keys are IDs for time series. For
- *     example
- *             {"a": [{"time": 0, "value": 1}, ...],
- *              "b": [{"time": 0, "value": 3}, ...]}
- *     are two time series with ids "a" and "b".
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param box_extent {Object} An object specifying the bounds for nodes which we
  *     should return as "in the box". It must have the keys,
  *       - x_min {float} The minimum x-value for the node to in order for it to
@@ -551,6 +540,8 @@ function lines_in_box(pairs, box_extent) {
  *
  * @param elem {d3 selection} The html selection on which all the .tree_nodes to
  *     check are located.
+ * @param {array of objects} pairs An with time / value pairs for each time
+ *      series line. For example, [{"time": 0, "value": 1}, ...]
  * @param brushes {array of d3-brush} An array containing all the d3-brushes on
  *     the display.
  * @return units {array of strings} The ids for tree nodes contained in any of

--- a/inst/htmlwidgets/lib/doi/ts_utils.js
+++ b/inst/htmlwidgets/lib/doi/ts_utils.js
@@ -71,7 +71,6 @@ function get_scales(values, width, height, size_min, size_max) {
  * @side-effects Draws the static time series (svg-paths) on the elem.
  **/
 function draw_ts(elem, dvalues, cur_lines, scales, mouseover_text) {
-  console.log(dvalues);
   var ts_select = draw_ts_internal(elem, dvalues, scales, "all_ts", cur_lines);
 
   if (mouseover_text) {
@@ -193,7 +192,7 @@ function timebox_node_attrs(dvalues, cur_lines, scales) {
  * @side-effects Draws the static tree structure (circles and paths between
  *     them) on elem.
  **/
-function draw_tree(elem, values, cur_lines, tree, scales, mouseover_text, dvalues) {
+function draw_tree(elem, dvalues, cur_lines, tree, scales, mouseover_text) {
   var hierarchy = d3.hierarchy(tree);
 
   // width + height info are in the scales

--- a/vignettes/setup_timeboxes.R
+++ b/vignettes/setup_timeboxes.R
@@ -48,7 +48,6 @@ mvalues <- do.call(rbind, values) %>%
 colnames(mvalues) <- c("time", "unit", "value")
 
 ##---- timebox-vis ----
-devtools::install()
 timebox_tree(mvalues, taxa, "Bacteria", 700, 500, size_min = 1, size_max = 20)
 
 ## ---- treebox-vis ----

--- a/vignettes/setup_timeboxes.R
+++ b/vignettes/setup_timeboxes.R
@@ -48,6 +48,7 @@ mvalues <- do.call(rbind, values) %>%
 colnames(mvalues) <- c("time", "unit", "value")
 
 ##---- timebox-vis ----
+devtools::install()
 timebox_tree(mvalues, taxa, "Bacteria", 700, 500, size_min = 1, size_max = 20)
 
 ## ---- treebox-vis ----


### PR DESCRIPTION
The time and treebox functions were hanging up because they were repeating a lot of the same computation (every time the brush was moved). This refactors some of the code for these functions so that the essential data structures are computed once at the beginning and passed along to each brush function.

This also indirectly closes #95 by including the same "zoom box" device introduced earlier for timeboxes. This seems like a better solution (keeping a fixed zooming frame, instead of transitioning each time the treebox selector is moved).
